### PR TITLE
Automatic update of Microsoft.Data.SqlClient to 2.0.1

### DIFF
--- a/FeedbackService/FeedbackService.Repo/FeedbackService.Repo.csproj
+++ b/FeedbackService/FeedbackService.Repo/FeedbackService.Repo.csproj
@@ -12,7 +12,7 @@
 		<PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="3.1.8" />
 		<PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="3.1.8" />
 		<PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.1.8" />
-		<PackageReference Include="Microsoft.Data.SqlClient" Version="1.1.3" />
+		<PackageReference Include="Microsoft.Data.SqlClient" Version="2.0.1" />
 		<PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="3.1.8">
 		  <PrivateAssets>all</PrivateAssets>
 		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
NuKeeper has generated a major update of `Microsoft.Data.SqlClient` to `2.0.1` from `1.1.3`
`Microsoft.Data.SqlClient 2.0.1` was published at `2020-08-25T23:33:24Z`, 28 days ago

1 project update:
Updated `FeedbackService\FeedbackService.Repo\FeedbackService.Repo.csproj` to `Microsoft.Data.SqlClient` `2.0.1` from `1.1.3`

[Microsoft.Data.SqlClient 2.0.1 on NuGet.org](https://www.nuget.org/packages/Microsoft.Data.SqlClient/2.0.1)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
