### PR TITLE
Automatic update of HelpMyStreet.CoreV3.Contracts to 1.1.378

### DIFF
--- a/FeedbackService/FeedbackService.Core/FeedbackService.Core.csproj
+++ b/FeedbackService/FeedbackService.Core/FeedbackService.Core.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="HelpMyStreet.CoreV3.Contracts" Version="1.1.369" />
+    <PackageReference Include="HelpMyStreet.CoreV3.Contracts" Version="1.1.378" />
     <PackageReference Include="MediatR" Version="8.1.0" />
   </ItemGroup>
 

--- a/FeedbackService/FeedbackService.Repo/FeedbackService.Repo.csproj
+++ b/FeedbackService/FeedbackService.Repo/FeedbackService.Repo.csproj
@@ -6,7 +6,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="AutoMapper" Version="10.0.0" />
-		<PackageReference Include="HelpMyStreet.CoreV3.Contracts" Version="1.1.369" />
+		<PackageReference Include="HelpMyStreet.CoreV3.Contracts" Version="1.1.378" />
 		<PackageReference Include="Microsoft.Azure.Services.AppAuthentication" Version="1.5.0" />
 		<PackageReference Include="Microsoft.EntityFrameworkCore" Version="3.1.8" />
 		<PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="3.1.8" />


### PR DESCRIPTION
NuKeeper has generated a patch update of `HelpMyStreet.CoreV3.Contracts` to `1.1.378` from `1.1.369`
`HelpMyStreet.CoreV3.Contracts 1.1.378` was published at `2020-09-23T13:42:14Z`, 2 hours ago

2 project updates:
Updated `FeedbackService\FeedbackService.Core\FeedbackService.Core.csproj` to `HelpMyStreet.CoreV3.Contracts` `1.1.378` from `1.1.369`
Updated `FeedbackService\FeedbackService.Repo\FeedbackService.Repo.csproj` to `HelpMyStreet.CoreV3.Contracts` `1.1.378` from `1.1.369`


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
